### PR TITLE
Fixed the dependency version specifier in Cartfile and Podspec

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Swinject/Swinject" ~> 2.0.0
+github "Swinject/Swinject" ~> 2.0

--- a/SwinjectPropertyLoader.podspec
+++ b/SwinjectPropertyLoader.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
-  s.dependency 'Swinject', '~> 2.0.0'
+  s.dependency 'Swinject', '~> 2.0'
   s.requires_arc = true
 end


### PR DESCRIPTION
Fixed the way to specify Swinject version to use v2.x.x (compatible versions with v2.0).
https://github.com/Swinject/SwinjectStoryboard/issues/48#issuecomment-296158221

Actually Cartfile doesn't need to be modified, but I changed it to align with podspec.